### PR TITLE
Dev

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sce"
-version = "0.1.3"
+version = "0.2.0"
 authors = ["Avi Srivastava <avi.srivastava@nyu.edu>", "Rob Patro <rob@cs.umd.edu>"]
 edition = "2021"
 description = "A library for importing and managing various single-cell matrices."

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,8 +1,8 @@
 [package]
 name = "sce"
-version = "0.1.2"
+version = "0.1.3"
 authors = ["Avi Srivastava <avi.srivastava@nyu.edu>", "Rob Patro <rob@cs.umd.edu>"]
-edition = "2018"
+edition = "2021"
 description = "A library for importing and managing various single-cell matrices."
 license-file = "LICENSE"
 readme= "README.md"
@@ -21,8 +21,9 @@ categories = ["command-line-utilities", "science"]
 
 [dependencies]
 num = "0.4.0"
-csv = "1.1.6"
-sprs = "0.11.0"
-flate2 = "1.0.23"
+csv = "1.2.2"
+sprs = "0.11.1"
+flate2 = "1.0.26"
 byteorder = "1.4.3"
 num-traits = "0.2.15"
+trait-set = "0.3.0"

--- a/src/csv.rs
+++ b/src/csv.rs
@@ -75,7 +75,7 @@ mod tests {
         )
     }
 
-    fn get_test_matrix_i64() -> CsMat<i64> {
+    fn get_test_matrix_usize() -> CsMat<usize> {
         CsMat::new(
             (3, 3),
             vec![0, 2, 4, 5],
@@ -98,8 +98,8 @@ mod tests {
         (a, b, c)
     }
 
-    fn get_test_sce_i64_data() -> (CsMat<i64>, Vec<String>, Vec<String>) {
-        let a = get_test_matrix_i64();
+    fn get_test_sce_usize_data() -> (CsMat<usize>, Vec<String>, Vec<String>) {
+        let a = get_test_matrix_usize();
         let b: Vec<String> = vec!["1", "2", "3"]
             .into_iter()
             .map(|x| x.to_string())
@@ -144,14 +144,14 @@ mod tests {
     }
 
     #[test]
-    fn test_csv_i64() {
-        let (a, b, c) = get_test_sce_i64_data();
+    fn test_csv_usize() {
+        let (a, b, c) = get_test_sce_usize_data();
         let sce = match SingleCellExperiment::from_csr(a, b.clone(), c.clone()) {
             Ok(x) => x,
             Err(y) => panic!("ERROR: {}", y),
         };
 
-        let file = get_temp_file(".csv.i64.gz".to_owned());
+        let file = get_temp_file(".csv.usize.gz".to_owned());
         let fname = file.to_str().unwrap();
         match sce.to_csv(fname) {
             Ok(_) => (),
@@ -159,7 +159,7 @@ mod tests {
         };
         println!("{:?}", fname);
 
-        let sce_csv: SingleCellExperiment<i64> = match SingleCellExperiment::from_csv(fname, b, c) {
+        let sce_csv: SingleCellExperiment<usize> = match SingleCellExperiment::from_csv(fname, b, c) {
             Ok(x) => x,
             Err(y) => panic!("ERROR: {}", y),
         };

--- a/src/csv.rs
+++ b/src/csv.rs
@@ -48,8 +48,8 @@ where
     for row_vec in matrix.outer_iterator() {
         columns.iter_mut().for_each(|x| *x = zero);
 
-        let mut it = row_vec.iter();
-        while let Some((col_idx, &val)) = it.next() {
+        let it = row_vec.iter();
+        for (col_idx, &val) in it {
             columns[col_idx] = val;
         }
 
@@ -159,7 +159,8 @@ mod tests {
         };
         println!("{:?}", fname);
 
-        let sce_csv: SingleCellExperiment<usize> = match SingleCellExperiment::from_csv(fname, b, c) {
+        let sce_csv: SingleCellExperiment<usize> = match SingleCellExperiment::from_csv(fname, b, c)
+        {
             Ok(x) => x,
             Err(y) => panic!("ERROR: {}", y),
         };

--- a/src/csv.rs
+++ b/src/csv.rs
@@ -75,7 +75,7 @@ mod tests {
         )
     }
 
-    fn get_test_matrix_usize() -> CsMat<usize> {
+    fn get_test_matrix_i64() -> CsMat<i64> {
         CsMat::new(
             (3, 3),
             vec![0, 2, 4, 5],
@@ -98,8 +98,8 @@ mod tests {
         (a, b, c)
     }
 
-    fn get_test_sce_usize_data() -> (CsMat<usize>, Vec<String>, Vec<String>) {
-        let a = get_test_matrix_usize();
+    fn get_test_sce_i64_data() -> (CsMat<i64>, Vec<String>, Vec<String>) {
+        let a = get_test_matrix_i64();
         let b: Vec<String> = vec!["1", "2", "3"]
             .into_iter()
             .map(|x| x.to_string())
@@ -144,14 +144,14 @@ mod tests {
     }
 
     #[test]
-    fn test_csv_usize() {
-        let (a, b, c) = get_test_sce_usize_data();
+    fn test_csv_i64() {
+        let (a, b, c) = get_test_sce_i64_data();
         let sce = match SingleCellExperiment::from_csr(a, b.clone(), c.clone()) {
             Ok(x) => x,
             Err(y) => panic!("ERROR: {}", y),
         };
 
-        let file = get_temp_file(".csv.usize.gz".to_owned());
+        let file = get_temp_file(".csv.i64.gz".to_owned());
         let fname = file.to_str().unwrap();
         match sce.to_csv(fname) {
             Ok(_) => (),
@@ -159,8 +159,7 @@ mod tests {
         };
         println!("{:?}", fname);
 
-        let sce_csv: SingleCellExperiment<usize> = match SingleCellExperiment::from_csv(fname, b, c)
-        {
+        let sce_csv: SingleCellExperiment<i64> = match SingleCellExperiment::from_csv(fname, b, c) {
             Ok(x) => x,
             Err(y) => panic!("ERROR: {}", y),
         };

--- a/src/eds.rs
+++ b/src/eds.rs
@@ -55,7 +55,7 @@ pub fn reader(
     num_cols: usize,
 ) -> Result<CsMat<MatValT>, Box<dyn Error>> {
     // reading the matrix
-    let file_handle = File::open(file_path.to_owned())?;
+    let file_handle = File::open(file_path)?;
     let buffered = BufReader::new(file_handle);
     let file = GzDecoder::new(buffered);
 
@@ -91,8 +91,8 @@ pub fn reader(
         }
         assert_eq!(num_ones, one_validator);
 
-        let mut expression: Vec<u8> = vec![0; mem::size_of::<MatValT>() * (num_ones as usize)];
-        let mut float_buffer: Vec<MatValT> = vec![0.0; num_ones as usize];
+        let mut expression: Vec<u8> = vec![0; mem::size_of::<MatValT>() * num_ones];
+        let mut float_buffer: Vec<MatValT> = vec![0.0; num_ones];
         file.read_exact(&mut expression[..])?;
 
         // NOTE: if we change MatValT, double check below line

--- a/src/file_names.rs
+++ b/src/file_names.rs
@@ -46,7 +46,7 @@ impl MatFileNames {
         let mut column_file = path.clone();
         column_file.push("genes.tsv");
 
-        let mut row_file = path.clone();
+        let mut row_file = path;
         row_file.push("barcodes.tsv");
 
         Ok(MatFileNames {
@@ -63,7 +63,7 @@ impl MatFileNames {
         let mut column_file = path.clone();
         column_file.push("features.tsv.gz");
 
-        let mut row_file = path.clone();
+        let mut row_file = path;
         row_file.push("barcodes.tsv.gz");
 
         Ok(MatFileNames {

--- a/src/iter.rs
+++ b/src/iter.rs
@@ -1,6 +1,11 @@
+use crate::MatrixValueTrait;
 use crate::SingleCellExperiment;
+use sprs::num_matrixmarket::Displayable;
 
-impl<'a, T> IntoIterator for &'a SingleCellExperiment<T> {
+impl<'a, T: MatrixValueTrait> IntoIterator for &'a SingleCellExperiment<T>
+where
+    for<'n> Displayable<&'n T>: std::fmt::Display,
+{
     type Item = SingleCellExperimentRow<'a, T>;
     type IntoIter = SingleCellExperimentIntoIterator<'a, T>;
 
@@ -13,13 +18,19 @@ impl<'a, T> IntoIterator for &'a SingleCellExperiment<T> {
     }
 }
 
-pub struct SingleCellExperimentRow<'a, T> {
+pub struct SingleCellExperimentRow<'a, T: MatrixValueTrait>
+where
+    for<'n> Displayable<&'n T>: std::fmt::Display,
+{
     row_id: usize,
     row_counts: sprs::CsVecBase<&'a [usize], &'a [T], T>,
     sce: &'a SingleCellExperiment<T>,
 }
 
-impl<'a, T> SingleCellExperimentRow<'a, T> {
+impl<'a, T: MatrixValueTrait> SingleCellExperimentRow<'a, T>
+where
+    for<'n> Displayable<&'n T>: std::fmt::Display,
+{
     pub fn name(&'a self) -> &'a String {
         &self.sce.rows[self.row_id]
     }
@@ -29,7 +40,10 @@ impl<'a, T> SingleCellExperimentRow<'a, T> {
     }
 }
 
-impl<'a, T> IntoIterator for &'a SingleCellExperimentRow<'a, T> {
+impl<'a, T: MatrixValueTrait> IntoIterator for &'a SingleCellExperimentRow<'a, T>
+where
+    for<'n> Displayable<&'n T>: std::fmt::Display,
+{
     type Item = SingleCellExperimentEntry<'a, T>;
     type IntoIter = SingleCellExperimentIntoRow<'a, T>;
 
@@ -41,13 +55,19 @@ impl<'a, T> IntoIterator for &'a SingleCellExperimentRow<'a, T> {
     }
 }
 
-pub struct SingleCellExperimentEntry<'a, T> {
+pub struct SingleCellExperimentEntry<'a, T: MatrixValueTrait>
+where
+    for<'n> Displayable<&'n T>: std::fmt::Display,
+{
     sce: &'a SingleCellExperiment<T>,
     count: &'a T,
     col_id: usize,
 }
 
-impl<'a, T> SingleCellExperimentEntry<'a, T> {
+impl<'a, T: MatrixValueTrait> SingleCellExperimentEntry<'a, T>
+where
+    for<'n> Displayable<&'n T>: std::fmt::Display,
+{
     pub fn id(&self) -> usize {
         self.col_id
     }
@@ -61,12 +81,18 @@ impl<'a, T> SingleCellExperimentEntry<'a, T> {
     }
 }
 
-pub struct SingleCellExperimentIntoRow<'a, T> {
+pub struct SingleCellExperimentIntoRow<'a, T: MatrixValueTrait>
+where
+    for<'n> Displayable<&'n T>: std::fmt::Display,
+{
     sce: &'a SingleCellExperiment<T>,
     row_it: sprs::vec::VectorIterator<'a, T, usize>,
 }
 
-impl<'a, T> Iterator for SingleCellExperimentIntoRow<'a, T> {
+impl<'a, T: MatrixValueTrait> Iterator for SingleCellExperimentIntoRow<'a, T>
+where
+    for<'n> Displayable<&'n T>: std::fmt::Display,
+{
     type Item = SingleCellExperimentEntry<'a, T>;
 
     fn next(&mut self) -> Option<Self::Item> {
@@ -82,13 +108,19 @@ impl<'a, T> Iterator for SingleCellExperimentIntoRow<'a, T> {
     }
 }
 
-pub struct SingleCellExperimentIntoIterator<'a, T> {
+pub struct SingleCellExperimentIntoIterator<'a, T: MatrixValueTrait>
+where
+    for<'n> Displayable<&'n T>: std::fmt::Display,
+{
     row_id: usize,
     sce: &'a SingleCellExperiment<T>,
     row_it: Box<dyn Iterator<Item = sprs::CsVecBase<&'a [usize], &'a [T], T>> + 'a>,
 }
 
-impl<'a, T> Iterator for SingleCellExperimentIntoIterator<'a, T> {
+impl<'a, T: MatrixValueTrait> Iterator for SingleCellExperimentIntoIterator<'a, T>
+where
+    for<'n> Displayable<&'n T>: std::fmt::Display,
+{
     type Item = SingleCellExperimentRow<'a, T>;
 
     fn next(&mut self) -> Option<Self::Item> {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -12,13 +12,22 @@ pub mod iter;
 pub mod mtx;
 pub mod utils;
 
+use sprs::num_matrixmarket::Displayable;
 use sprs::CsMat;
 use std::error::Error;
 use std::fmt;
 use std::path::{Path, PathBuf};
+use trait_set::trait_set;
+
+trait_set! {
+    pub trait MatrixValueTrait = sprs::num_matrixmarket::MatrixMarketRead + sprs::num_matrixmarket::MatrixMarketConjugate + sprs::num_kinds::PrimitiveKind + std::ops::Add;
+}
 
 #[derive(PartialEq)]
-pub struct SingleCellExperiment<T> {
+pub struct SingleCellExperiment<T: MatrixValueTrait>
+where
+    for<'n> Displayable<&'n T>: std::fmt::Display,
+{
     counts: CsMat<T>,
     rows: Vec<String>,
     cols: Vec<String>,
@@ -30,7 +39,10 @@ pub enum MatrixKind {
     MTX,
 }
 
-impl<T> fmt::Debug for SingleCellExperiment<T> {
+impl<T: MatrixValueTrait> fmt::Debug for SingleCellExperiment<T>
+where
+    for<'n> Displayable<&'n T>: std::fmt::Display,
+{
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.debug_struct("SingleCellExperiment")
             .field("matrix (#rows, #columns)", &self.shape())
@@ -38,7 +50,10 @@ impl<T> fmt::Debug for SingleCellExperiment<T> {
     }
 }
 
-impl<T> SingleCellExperiment<T> {
+impl<T: MatrixValueTrait> SingleCellExperiment<T>
+where
+    for<'n> Displayable<&'n T>: std::fmt::Display,
+{
     pub fn cols(&self) -> usize {
         self.counts.cols()
     }
@@ -102,19 +117,21 @@ impl<T> SingleCellExperiment<T> {
         Ok(SingleCellExperiment { counts, rows, cols })
     }
 
+    /*
     pub fn from_mtx(
         file_path: &str,
         rows: Vec<String>,
         cols: Vec<String>,
     ) -> Result<SingleCellExperiment<T>, Box<dyn Error>>
     where
-        T: Clone + num_traits::Num + num_traits::NumCast,
+        T: Clone + num_traits::Num + num_traits::NumCast + std::ops::Neg<Output=T>,
     {
         let file = Path::new(file_path);
         let counts: CsMat<T> = mtx::reader(file)?;
 
         Ok(SingleCellExperiment { counts, rows, cols })
     }
+    */
 
     pub fn from_csv(
         file_path: &str,
@@ -144,6 +161,59 @@ impl<T> SingleCellExperiment<T> {
     {
         let file = Path::new(file_path);
         csv::writer(file, self.counts())
+    }
+    /*
+    pub fn from_tenx_v2(cr_out: PathBuf) -> Result<SingleCellExperiment<T>, Box<dyn Error>>
+    where
+        T: Copy + num::Num + num::NumCast,
+    {
+        let file_names = file_names::MatFileNames::tenx_v2(cr_out)?;
+
+        let feature_names = utils::read_features(file_names.column_file())?;
+        let cellbarcode_names = utils::read_features(file_names.row_file())?;
+
+        Ok(SingleCellExperiment::from_mtx(
+            file_names.matrix_file().to_str().unwrap(),
+            cellbarcode_names,
+            feature_names,
+        )?)
+    }
+
+    pub fn from_tenx_v3(cr_out: PathBuf) -> Result<SingleCellExperiment<T>, Box<dyn Error>>
+    where
+        T: Copy + num::Num + num::NumCast,
+    {
+        let file_names = file_names::MatFileNames::tenx_v2(cr_out)?;
+
+        let feature_names = utils::read_compressed_features(file_names.column_file())?;
+        let cellbarcode_names = utils::read_compressed_features(file_names.row_file())?;
+
+        Ok(SingleCellExperiment::from_mtx(
+            file_names.matrix_file().to_str().unwrap(),
+            cellbarcode_names,
+            feature_names,
+        )?)
+    }
+    */
+}
+
+impl<T: MatrixValueTrait> SingleCellExperiment<T>
+where
+    T: std::ops::Neg<Output = T>,
+    for<'n> Displayable<&'n T>: std::fmt::Display,
+{
+    pub fn from_mtx(
+        file_path: &str,
+        rows: Vec<String>,
+        cols: Vec<String>,
+    ) -> Result<SingleCellExperiment<T>, Box<dyn Error>>
+    where
+        T: Clone + num_traits::Num + num_traits::NumCast + std::ops::Neg<Output = T>,
+    {
+        let file = Path::new(file_path);
+        let counts: CsMat<T> = mtx::reader(file)?;
+
+        Ok(SingleCellExperiment { counts, rows, cols })
     }
 
     pub fn from_tenx_v2(cr_out: PathBuf) -> Result<SingleCellExperiment<T>, Box<dyn Error>>

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -225,11 +225,11 @@ where
         let feature_names = utils::read_features(file_names.column_file())?;
         let cellbarcode_names = utils::read_features(file_names.row_file())?;
 
-        Ok(SingleCellExperiment::from_mtx(
+        SingleCellExperiment::from_mtx(
             file_names.matrix_file().to_str().unwrap(),
             cellbarcode_names,
             feature_names,
-        )?)
+        )
     }
 
     pub fn from_tenx_v3(cr_out: PathBuf) -> Result<SingleCellExperiment<T>, Box<dyn Error>>
@@ -241,11 +241,11 @@ where
         let feature_names = utils::read_compressed_features(file_names.column_file())?;
         let cellbarcode_names = utils::read_compressed_features(file_names.row_file())?;
 
-        Ok(SingleCellExperiment::from_mtx(
+        SingleCellExperiment::from_mtx(
             file_names.matrix_file().to_str().unwrap(),
             cellbarcode_names,
             feature_names,
-        )?)
+        )
     }
 }
 
@@ -272,11 +272,11 @@ impl SingleCellExperiment<f32> {
         let feature_names = utils::read_features(file_names.column_file())?;
         let cellbarcode_names = utils::read_features(file_names.row_file())?;
 
-        Ok(SingleCellExperiment::from_eds(
+        SingleCellExperiment::from_eds(
             file_names.matrix_file().to_str().unwrap(),
             cellbarcode_names,
             feature_names,
-        )?)
+        )
     }
 
     pub fn from_mat_file_names(

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -7,7 +7,7 @@ use flate2::read::GzDecoder;
 
 pub fn read_features(file_path: PathBuf) -> Result<Vec<String>, Box<dyn Error>> {
     let file_content = std::fs::read_to_string(file_path)?;
-    let mut features: Vec<String> = file_content.split("\n").map(|x| x.to_owned()).collect();
+    let mut features: Vec<String> = file_content.split('\n').map(|x| x.to_owned()).collect();
     features.pop();
 
     Ok(features)
@@ -18,7 +18,7 @@ pub fn read_compressed_features(file_path: PathBuf) -> Result<Vec<String>, Box<d
     let mut file_content = String::new();
     gz.read_to_string(&mut file_content)?;
 
-    let mut features: Vec<String> = file_content.split("\n").map(|x| x.to_owned()).collect();
+    let mut features: Vec<String> = file_content.split('\n').map(|x| x.to_owned()).collect();
     features.pop();
 
     Ok(features)


### PR DESCRIPTION
Merge dev into master:

This release allows upgrade to `sprs` 0.11.1 from 0.11.0.  Despite just being a "patch" release, 0.11.1 completely changed several required traits.  This addresses those concerns and also does a bit of other cleanup.

**Note** : One change in `sprs` is that they now statically enforce the matrix market requirement that the supported types are `patter`, `integer`, `complex` or `real`.  That is, they disallow `unsigned` types as the result of reading a matrix market format file.  This means that the `from_mtx` function of `SingleCellExperiment<T>` (and the other functions that use this one) can *only* be used where `T: std::ops::Neg<Output=T>`.  So, for example, you can do `from_mtx` for a `SingleCellExperiment<i32>` but not for a `SingleCellExperiment<u32>`.  @k3yavi and I decided this flexibility was desirable compared to the alternative of simply enforcing that `SingleCellExperiment` must always be parameterized on a singed type.